### PR TITLE
fix encoding issue on Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,16 @@
-import sys
+import sys, codecs
 from MaterialPlanning import MaterialPlanning
 
 if __name__ == '__main__':
     
     mp = MaterialPlanning()
     
-    with open('required.txt', 'r') as f:
+    with codecs.open('required.txt', 'r', 'utf-8') as f:
         required_dct = {}
         for line in f.readlines():
             required_dct[line.split(' ')[0]] = int(line.split(' ')[1])
             
-    with open('owned.txt', 'r') as f:
+    with codecs.open('owned.txt', 'r', 'utf-8') as f:
         owned_dct = {}
         for line in f.readlines():
             owned_dct [line.split(' ')[0]] = int(line.split(' ')[1])


### PR DESCRIPTION
对于 Windows （以及某些情况下的 Linux），python 默认使用的编码并不是 utf-8。

顺带一提，似乎现在版本的后端引入了一些 bug。