### PR TITLE
Give a name to Sanic app

### DIFF
--- a/server.py
+++ b/server.py
@@ -5,7 +5,7 @@ import click
 from sanic import Sanic, response
 from MaterialPlanning import MaterialPlanning
 
-app = Sanic()
+app = Sanic(name='ArkPlanner')
 
 app.static('/', './ArkPlannerWeb/index.html')
 app.static('/css', './ArkPlannerWeb/css')


### PR DESCRIPTION
Running `python server.py` will give a warning:
```text
server.py:8: DeprecationWarning: Sanic(name=None) is deprecated and None value support for `name` will be removed in the next release. Please use Sanic(name='your_application_name') instead.
  app = Sanic()
```

So this PR gives a name to the Sanic app.